### PR TITLE
fix: don't show deleted types

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -100,11 +100,13 @@ function TypesSelect({
           {getTypes(schema).map(({ groupLabel, types }) => {
             return (
               <optgroup key={groupLabel} label={groupLabel}>
-                {types.map((type) => (
-                  <option key={type.id} value={type.id}>
-                    {type.name}
-                  </option>
-                ))}
+                {types
+                  .filter((type) => false === type.name.endsWith("_deleted"))
+                  .map((type) => (
+                    <option key={type.id} value={type.id}>
+                      {type.name}
+                    </option>
+                  ))}
               </optgroup>
             );
           })}


### PR DESCRIPTION
The API probably shouldn't return these, but it does. There's no property returned to suggest it's deleted, but they are all named BLAH_deleted. So let's filter them out.

Signed-off-by: David Flanagan <david@rawkode.dev>